### PR TITLE
Add support for additional key/value pairs in X-MoneyTrace header

### DIFF
--- a/trace.go
+++ b/trace.go
@@ -34,7 +34,7 @@ func decodeTraceContext(raw string) (tc *TraceContext, err error) {
 
 	pairs := strings.Split(raw, ";")
 
-	if len(pairs) != 3 {
+	if len(pairs) < 3 {
 		return nil, errPairsCount
 	}
 
@@ -66,10 +66,11 @@ func decodeTraceContext(raw string) (tc *TraceContext, err error) {
 				return nil, err
 			}
 			tc.PID, seen[k] = pv, true
-
-		default:
-			return nil, errBadTrace
 		}
+	}
+
+	if (!seen[tIDKey] || !seen[sIDKey] || !seen[pIDKey]) {
+		return nil, errBadTrace
 	}
 
 	return

--- a/trace_test.go
+++ b/trace_test.go
@@ -27,6 +27,16 @@ func TestDecodeTraceContext(t *testing.T) {
 			},
 			e: nil,
 		},
+		{
+			name: "extra",
+			i:    "trace-id=de305d54-75b4-431b-adb2-eb6b9e546013;parent-id=3285573610483682037;span-id=3285573610483682037;sampled=1",
+			o: &TraceContext{
+				PID: 3285573610483682037,
+				SID: 3285573610483682037,
+				TID: "de305d54-75b4-431b-adb2-eb6b9e546013",
+			},
+			e: nil,
+		},
 
 		{
 			name: "duplicateEntries",
@@ -44,6 +54,27 @@ func TestDecodeTraceContext(t *testing.T) {
 		{
 			name: "NoRealPairs",
 			i:    "one=1;two=2;three=3",
+			o:    nil,
+			e:    errBadTrace,
+		},
+
+		{
+			name: "missingTraceId",
+			i:    "foo=bar;parent-id=3285573610483682037;span-id=3285573610483682037",
+			o:    nil,
+			e:    errBadTrace,
+		},
+
+		{
+			name: "missingParentId",
+			i:    "trace-id=de305d54-75b4-431b-adb2-eb6b9e546013;foo=bar;span-id=3285573610483682037",
+			o:    nil,
+			e:    errBadTrace,
+		},
+
+		{
+			name: "missingSpanId",
+			i:    "trace-id=de305d54-75b4-431b-adb2-eb6b9e546013;parent-id=3285573610483682037;foo=bar",
 			o:    nil,
 			e:    errBadTrace,
 		},


### PR DESCRIPTION
Adds support for additional unrecognized key/value pairs in the `X-MoneyTrace` header.  The header will be considered value as long as it has at least 3 key/value pairs and that each of the `trace-id`,`parent-id` and `span-id` keys have been seen.  Any other key/value pairs will be ignored.

See: https://github.com/xmidt-org/golang-money/issues/43
https://github.com/Comcast/money/pull/158